### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# Arduino language support in Atom
+# Arduino language for Particle brand boards support in Atom
 
-Adds syntax highlighting and snippets to Arduino files in Atom.
+Adds syntax highlighting and snippets to Arduino files with Particle syntax in Atom.
 
 Inherits C++ syntax from [language-c](https://atom.io/packages/language-c) package.
 
+Package based upon the base [Arduino syntax library](https://github.com/szechyjs/language-arduino) from [szechyjs](https://github.com/szechyjs).
+
 Contributions are greatly appreciated. Please fork this repository and open a
-pull request to add snippets, make gramar tweaks, etc.
+pull request to add snippets, make grammar tweaks, etc.


### PR DESCRIPTION
clarify in readme that this library inherits from a user, and that the syntax is specifically designed for Particle boards. Also fixes a spelling error.